### PR TITLE
Read color value from Spectrum widget

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/create-group.hbs
+++ b/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/create-group.hbs
@@ -21,7 +21,9 @@
       style="padding: 5px; width: 50%;"
       value=""
       placeholder="Description">
-    <input type='color' name='color' />
+    <input
+      class="color"
+      name='color' />
     <button
       type="button"
       class="btn btn-primary create"

--- a/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/create-group.js.es6
+++ b/assets/javascripts/discourse/templates/connectors/discovery-list-container-top/create-group.js.es6
@@ -6,7 +6,7 @@ import {withPluginApi} from 'discourse/lib/plugin-api';
 
 // For debugging
 function log() {
-  console.log.apply(console, arguments);
+  // console.log.apply(console, arguments);
 }
 
 
@@ -92,32 +92,18 @@ function setupColorPicker($colorPickerEl) {
     // Don't store selections in palette
     showSelectionPalette: false,
     selectionPalette: [],
-    maxSelectionSize: 0,
-
-  
-    preferredFormat: "hex",
-    localStorageKey: "spectrum.demo",
-
-    hide: onColorHide,
-    change: onColorChange
+    maxSelectionSize: 0
   });
-}
-
-function onColorHide(color) {
-  console.log('hide', color);
-}
-
-function onColorChange(color) {
-  console.log('change', color);
 }
 
 function onCreateGroupClicked($containerEl, e) {
   log('group:onCreateGroupClicked');
   // Read data from the form
-  var formData = {
+  const color = $containerEl.find('.color').spectrum('get').toHex();
+  const formData = {
     name: $containerEl.find('.name').val(),
     description: $containerEl.find('.description').val(),
-    color: $containerEl.find('.color').spectrum('get'),
+    color: color,
     text_color: '000000',
     csrf: $('meta[name="csrf-token"]').attr('content')
   };


### PR DESCRIPTION
Also disallow native HTML5, so it stays consistent and matches local testing:

<img width="816" alt="screen shot 2017-03-10 at 12 13 29 pm" src="https://cloud.githubusercontent.com/assets/1056957/23805697/ec76ffea-058c-11e7-9634-989f23fb81cc.png">
